### PR TITLE
Add support for when steamButton is not last button

### DIFF
--- a/stprofile.user.js
+++ b/stprofile.user.js
@@ -12,7 +12,7 @@
     'use strict';
 
     var buttonList = $('div.sidebar__shortcut-inner-wrap');
-    var steamButton = buttonList.children().last();
+    var steamButton = buttonList.children('a[href*="steamcommunity.com"]');
     var tradeButton = steamButton.clone();
     tradeButton.html('<i class="fa fa-fw"><img src="https://cdn.steamtrades.com/img/favicon.ico"/></i>');
     var href = tradeButton.attr('href');


### PR DESCRIPTION
The previous code would simply get the last children element, the new code figures out which one is the correct button with the link we are after so that it doesn't break when using other scripts that append buttons.