### PR TITLE
Stop hiding group giveaways on group/user pages.

### DIFF
--- a/sggroupidentifier.user.js
+++ b/sggroupidentifier.user.js
@@ -14,6 +14,7 @@ let limit = 8;
 
 function _showGroups(context, item) {
 	let hide = false;
+    let Path = window.location.pathname;
     let names = [];
     $(context).find('a.table__column__heading').each(function(i, g) {
         names.push({"link": $(g).attr('href'), "name": htmlEncode($(g).text())});
@@ -33,6 +34,10 @@ function _showGroups(context, item) {
         i++;
     });
     $(item).append('<div class="giveaway__row-inner-wrap"><div class="giveaway__summary"><div class="giveaway__columns">'+res+'</div></div></div>');
+    
+	//When you are on your own user page, or on the specific group page, don't hide the giveaway.
+    if(Path.match(/^\/user\//)) hide = false;
+    if(Path.match(/^\/group\//)) hide = false;
     if(hide) {
     	$(item).hide();
     }


### PR DESCRIPTION
There are certain groups, where I have to respect their rules on whether I can enter their giveaways or not.  As a result, I don't want to see those groups on the front page, or in any of the front page searching options.   I do likewise however, wish to see ALL the giveaways however, on both user pages, (for when dealing with reporting unactivated wins or duplicate wins),  and on group pages,  (for browsing for giveaways there for ones I may be allowed to enter based on the group rules.)

Just today, I got blindsided on a wishlist search, and entered every giveaway on that page that I had not entered already, that I had enough points for,  and accidentally entered one that I was NOT allowed to enter, according to a specific groups rules.  Exactly why I want to hide groups,  but ONLY on the front page / searches where I do my mass manually selected giveaway entries from.